### PR TITLE
Remove an 'alert()' command

### DIFF
--- a/resources/js/companies/index.js
+++ b/resources/js/companies/index.js
@@ -15,7 +15,6 @@ $(function() {
                 success: function(response) {
                     // Remove the row from the table
                     row.remove();
-                    alert(response.success);
                 },
                 error: function(response) {
                     // Display error if failed


### PR DESCRIPTION
Removed response.success message from index.js for companies.index view... because the success (of deleting a company) is obvious anyway