### PR TITLE
Hotfix: create multiple delete form for tables entries

### DIFF
--- a/app/Http/Controllers/CompanyController.php
+++ b/app/Http/Controllers/CompanyController.php
@@ -110,7 +110,7 @@ class CompanyController extends Controller
         $company->delete();
 
         // Return a JSON response
-        return response()->json(['success' => 'Company deleted successfully']);
+        return redirect()->route('companies.index')->with('success', 'Company deleted successfully');
     }
 
 

--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -73,15 +73,19 @@ class EmployeeController extends Controller
         // Redirect to employees list of the company after successful creation
         return redirect()->route('companies.show', ['company' => $validatedData['company_id']]);
     }
-    public function destroy($id)
+
+    public function destroy($id, Request $request)
     {
+
+
         // Delete the company from the database (if it exists)
-        $employee = Employee::findOrFail($id);
-        $employee->delete();
+        $company = Employee::findOrFail($id);
+        $company->delete();
 
         // Return a JSON response
-        return response()->json(['success' => 'Employee deleted successfully']);
+        return redirect()->route('companies.show', ['company' => $request['company_id']])->with('success', 'Employee deleted successfully');
     }
+
     public function create(CreateEmployeeRequest $request)
     {
         $company_id = $request->validated()['company_id'];

--- a/resources/js/companies/index.js
+++ b/resources/js/companies/index.js
@@ -1,11 +1,9 @@
 $(function() {
     
-    // Get the CSRF token for secure 'DELETE' requests
-    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-
     // Initialize Companies DataTable with server-side processing
     var originalTableTemplateContent = $('#companies-table');
     var actions = originalTableTemplateContent.find('.actions');
+    var formActionUrlTemplate = originalTableTemplateContent.find('form').attr('action');
     var urlTemplate = actions.find('a').attr('data-url');
     $('#companies-table').removeClass('hidden').DataTable({
         processing: true, // Show a processing indicator when the table is loading
@@ -34,6 +32,8 @@ $(function() {
                     var companyUrl = urlTemplate.replace(':company', data.id);
                     actions.find('a').attr('href', companyUrl);
                     actions.find('.delete-btn').attr('data-id', data.id);
+                    var formActionUrl = formActionUrlTemplate.replace(':company', data.id);
+                    actions.find('form').attr('action', formActionUrl);
                     return actions.html();
                 }
             }
@@ -45,26 +45,5 @@ $(function() {
         columnDefs: [
             { orderable: false, targets: '_all' } // Disable sorting on all columns
         ]
-    });
-
-    // Handle Delete button click
-    $(document).on('click', '.delete-btn', function () {
-        const id = $(this).data('id'); // Get the ID of the selected company
-
-        // Send AJAX request to delete the record
-        $.ajax({
-            url: `/companies/${id}`, // URL to delete the specific company
-            type: 'DELETE', // HTTP method for deletion
-            headers: {
-                'X-CSRF-TOKEN': csrfToken, // Send CSRF token for security
-            },
-            success: function () {
-                $('#companies-table').DataTable().ajax.reload(); // Reload the table data after successful deletion
-            },
-            error: function (xhr, status, error) {
-                console.error('Error deleting record:', error);
-                alert('Failed to delete record.');
-            }
-        });
     });
 });

--- a/resources/js/companies/show.js
+++ b/resources/js/companies/show.js
@@ -1,8 +1,5 @@
 $(function() {
     
-    // Get the CSRF token for secure 'DELETE' requests
-    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-    
     // Initialize current company DataTable for the company details
     $('#companies-table').removeClass('hidden').DataTable({
         pageLength: 1, 
@@ -21,6 +18,7 @@ $(function() {
     // Initialize Employees DataTable with server-side processing
     var originalTableTemplateContent = $('#employees-table');
     var actions = originalTableTemplateContent.find('.actions');
+    var formActionUrlTemplate = originalTableTemplateContent.find('form').attr('action');
     var urlTemplate = actions.find('a').attr('data-url');
     $('#employees-table').removeClass('hidden').DataTable({
         processing: true, // Show a processing indicator when the table is loading
@@ -44,6 +42,8 @@ $(function() {
                     var companyUrl = urlTemplate.replace(':employee', data.id);
                     actions.find('a').attr('href', companyUrl);
                     actions.find('.delete-btn').attr('data-id', data.id);
+                    var formActionUrl = formActionUrlTemplate.replace(':employee', data.id);
+                    actions.find('form').attr('action', formActionUrl);
                     return actions.html();
                 }
             }
@@ -55,26 +55,5 @@ $(function() {
         columnDefs: [
             { orderable: false, targets: '_all' } // Disable sorting on all columns
         ]
-    });
-
-    // Handle Delete button click
-    $(document).on('click', '.delete-btn', function () {
-        const id = $(this).data('id'); // Get the ID of the selected employee
-
-        // Send AJAX request to delete the record
-        $.ajax({
-            url: `/employees/${id}`, // URL to delete the specific employee
-            type: 'DELETE', // HTTP method for deletion
-            headers: {
-                'X-CSRF-TOKEN': csrfToken, // Send CSRF token for security
-            },
-            success: function () {
-                $('#employees-table').DataTable().ajax.reload(); // Reload the table data after successful deletion
-            },
-            error: function (xhr, status, error) {
-                console.error('Error deleting record:', error);
-                alert('Failed to delete record.');
-            }
-        });
     });
 });

--- a/resources/views/companies/index.blade.php
+++ b/resources/views/companies/index.blade.php
@@ -50,14 +50,17 @@
                                             </td> 
                                             <!-- "Details" and "Delete" buttons -->
                                             <td class="px-4 py-2 border actions">
-                                                <a href="#" data-url="{{ route('companies.show', ['company' => ':company']) }}">
-                                                    <button class="edit-btn bg-white border border-blue-500 text-blue-500 px-2 py-1 rounded hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50">
+                                                <form method="POST" action="{{ route('companies.destroy', ['company' => ':company']) }}" >
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <a href="#" data-url="{{ route('companies.show', ['company' => ':company']) }}" 
+                                                       class="edit-btn bg-white border border-blue-500 text-blue-500 px-2 py-1 rounded hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50">
                                                         {{ __('Details') }}
+                                                    </a>
+                                                    <button type="submit" data-id="" class="delete-btn bg-orange-500 text-white px-2 py-1 rounded hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-opacity-50">
+                                                        {{ __('Delete') }}
                                                     </button>
-                                                </a>
-                                                <button data-id="${data.id}" class="delete-btn bg-orange-500 text-white px-2 py-1 rounded hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-opacity-50">
-                                                    {{ __('Delete') }}
-                                                </button>
+                                                </form>
                                             </td>
                                         </tr>
                                     </tbody>

--- a/resources/views/companies/show.blade.php
+++ b/resources/views/companies/show.blade.php
@@ -97,14 +97,21 @@
                                             </td> 
                                             <!-- "Edit" and "Delete" buttons -->
                                             <td class="px-4 py-2 border actions">
-                                                <a href="#" data-url="{{ route('employees.edit', ['employee' => ':employee']) }}">
-                                                    <button class="bg-white border border-blue-500 text-blue-500 px-2 py-1 rounded hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50">
+                                                <form method="POST" action="{{ route('employees.destroy', ['employee' => ':employee']) }}" onsubmit="return confirm('Are you sure you want to delete this employee?');">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <input type="hidden" name="company_id" value="{{ $company->id }}"/>
+                                                    <!-- Edit Button as a Link -->
+                                                    <a href="#" data-url="{{ route('employees.edit', ['employee' => ':employee']) }}" 
+                                                       class="bg-white border border-blue-500 text-blue-500 px-2 py-1 rounded hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50">
                                                         {{ __('Edit') }}
+                                                    </a>
+                                                    <!-- Delete Button as a Form Submit Button -->
+                                                    <button type="submit" 
+                                                            class="delete-btn bg-orange-500 text-white px-2 py-1 rounded hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-opacity-50">
+                                                        {{ __('Delete') }}
                                                     </button>
-                                                </a>
-                                                <button data-id="${data.id}" class="delete-btn bg-orange-500 text-white px-2 py-1 rounded hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-opacity-50">
-                                                    {{ __('Delete') }}
-                                                </button>
+                                                </form>
                                             </td>
                                         </tr>
                                     </tbody>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="csrf-token" content="{{ csrf_token() }}">
+
 
         <title>{{ config('app.name', 'Laravel') }}</title>
 


### PR DESCRIPTION
Now instead of a csrf token in <head><meta></head> each entry in the employees and companies tables has a delete form which is better practice